### PR TITLE
xf86-input-mouse is unneeded

### DIFF
--- a/bundles/os-utils-gui
+++ b/bundles/os-utils-gui
@@ -72,7 +72,6 @@ xdg-utils
 xdg-user-dirs
 xemacs
 xf86-input-evdev
-xf86-input-mouse
 xf86-input-synaptics
 xf86-video-fbdev
 xf86-video-vesa


### PR DESCRIPTION
xf86-input-mouse is unneeded, because xf86-input-evdev is providing same functions