### PR TITLE
Add the telemetrics-client-dev to the os-clr-on-clr bundle

### DIFF
--- a/bundles/os-clr-on-clr
+++ b/bundles/os-clr-on-clr
@@ -71,6 +71,7 @@ rpm-common
 sbsigntools
 scons
 six
+telemetrics-client-dev
 unbundle
 urlgrabber
 xcb-proto-dev


### PR DESCRIPTION
This is required today in order to build acrn-crashlog which
is a tool developed by Project ACRN (https://projectacrn.org)

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>