### PR TITLE
mixer: Add docker

### DIFF
--- a/bundles/mixer
+++ b/bundles/mixer
@@ -14,6 +14,7 @@ include(sysadmin-basic)
 bundle-chroot-builder
 createrepo_c
 dnf
+docker
 hardlink
 # dependency for bundle-chroot-builder, remove at the same time
 m4


### PR DESCRIPTION
Mixer now uses docker as default to build packages, so it must be added
as a dependency of the mixer package.

Signed-off-by: Rodrigo Chiossi <rodrigo.chiossi@intel.com>