### PR TITLE
Add official display manager

### DIFF
--- a/bundles/desktop-kde
+++ b/bundles/desktop-kde
@@ -54,6 +54,7 @@ plasma-pa
 plasma-vault
 plasma-workspace
 plasma-workspace-wallpapers
+sddm
 systemsettings
 user-manager
 xdg-desktop-portal


### PR DESCRIPTION
If this bundle is installed with the desktop bundle, users will use GDM to login to Plasma, which is not recommended by KDE. If installed without GDM, the user will have no DM installed. SDDM is packaged in Clear Linux and is officially recommended by KDE to launch Plasma.

Note: Extended description in the commit has a typo. It should read "If installed **without** GDM..." in the second sentence.