### PR TITLE
Add rpcbind to storage-cluster which is required by GlusterFS

### DIFF
--- a/bundles/storage-cluster
+++ b/bundles/storage-cluster
@@ -13,4 +13,5 @@ ceph-deploy
 pip-legacypython
 glusterfs
 parted
+rpcbind
 xfsprogs


### PR DESCRIPTION
This was pointed out in the #clearlinux IRC channel by Squid.

rpcbind is a requirement for GlusterFS in the systemd service unit due it being packaged with NFS:
https://github.com/gluster/glusterfs/blob/master/extras/systemd/glusterd.service.in