### PR TITLE
Use IAS for software-defined-cockpit instead of weston

### DIFF
--- a/bundles/software-defined-cockpit
+++ b/bundles/software-defined-cockpit
@@ -12,11 +12,9 @@ gst-plugins-base
 gst-plugins-good
 gstreamer
 gstreamer-vaapi
+ias
 ioc-cbc-tools
 libva
 libva-intel-driver
 pulseaudio
-wayland
-wayland-protocols
-weston
 xkeyboard-config


### PR DESCRIPTION
generic weston is not appropriate for software defined cockpit.
IAS replaces weston functionality and is automotive specific.

Signed-off-by: Kevron Rees <kevron.m.rees@intel.com>