### PR TITLE
add apr-util-dev to sysadmin-basic-dev

### DIFF
--- a/bundles/sysadmin-basic-dev
+++ b/bundles/sysadmin-basic-dev
@@ -13,6 +13,7 @@ Linux-PAM-dev32
 acl-dev
 acl-dev32
 apr-dev
+apr-util-dev
 asciidoc
 aspell
 aspell-dev


### PR DESCRIPTION
Currently sysadmin-basic-dev has only apr-dev, which is not enough
for some cases to manage and config Apache2 modules, e.g. in the
initialization stage of DevStack script(for OpenStack).