### PR TITLE
bundles: Add new geany pundle

### DIFF
--- a/bundles/geany
+++ b/bundles/geany
@@ -1,0 +1,10 @@
+# [TITLE]: geany
+# [DESCRIPTION]: Geany is a GTK text editor with basic IDE features
+# [STATUS]: Active
+# [CAPABILITIES]:
+# [MAINTAINER]: Ikey Doherty <ikey.doherty@intel.com>
+# Geany requires GNOME libraries, GIR and Python for Plugins
+include(desktop-gnomelibs)
+geany
+geany-plugins
+


### PR DESCRIPTION
This allows a smaller download size to access the Geany text editor without
requiring the larger bundles to facilitate a basic IDE-style environment
for development for those that cannot work without Geany. Such as me.

Signed-off-by: Ikey Doherty <ikey.doherty@intel.com>