### PR TITLE
remove linux-pk414 package from service-os

### DIFF
--- a/bundles/service-os
+++ b/bundles/service-os
@@ -8,7 +8,6 @@
 include(bootloader)
 linux-firmware
 linux-firmware-ipu4
-linux-pk414-sos
 linux-iot-lts2018-sos
 mcelog
 


### PR DESCRIPTION
We have migrated to use linux-iot-lts2018 for service-os.
Removing linux-pk414 from the bundle to reduce bundle size.

Signed-off-by: Chang, Rebecca Swee Fun <rebecca.swee.fun.chang@intel.com>