### PR TITLE
Add descriptions to "No detailed summary available" bundles

### DIFF
--- a/bundles/conky
+++ b/bundles/conky
@@ -1,5 +1,5 @@
 # [TITLE]: conky
-# [DESCRIPTION]: No detailed summary available
+# [DESCRIPTION]: A light-weight system monitor
 # [STATUS]: Active
 # [CAPABILITIES]:
 # [TAGS]:

--- a/bundles/minicom
+++ b/bundles/minicom
@@ -1,5 +1,5 @@
 # [TITLE]: minicom
-# [DESCRIPTION]: No detailed summary available
+# [DESCRIPTION]: A text-based serial port communications program
 # [STATUS]: Active
 # [CAPABILITIES]:
 # [TAGS]:

--- a/bundles/vinagre
+++ b/bundles/vinagre
@@ -1,5 +1,5 @@
 # [TITLE]: vinagre
-# [DESCRIPTION]: No detailed summary available
+# [DESCRIPTION]: A remote desktop viewer for GNOME desktop
 # [STATUS]: Active
 # [CAPABILITIES]:
 # [TAGS]:

--- a/bundles/wget
+++ b/bundles/wget
@@ -1,5 +1,5 @@
 # [TITLE]: wget
-# [DESCRIPTION]: No detailed summary available
+# [DESCRIPTION]: Utility to retrieve content from web servers
 # [STATUS]: Active
 # [CAPABILITIES]:
 # [TAGS]:

--- a/bundles/x11vnc
+++ b/bundles/x11vnc
@@ -1,5 +1,5 @@
 # [TITLE]: x11vnc
-# [DESCRIPTION]: No detailed summary available
+# [DESCRIPTION]: A VNC server for real X displays
 # [STATUS]: Active
 # [CAPABILITIES]:
 # [TAGS]:


### PR DESCRIPTION
Some bundles don't have the right descriptions in their bundle definition files.

Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>