### PR TITLE
software-testing: include cmocka-dev

### DIFF
--- a/bundles/software-testing
+++ b/bundles/software-testing
@@ -12,7 +12,7 @@ include(python-testing)
 
 bats
 check
-cmocka
+cmocka-dev
 glog
 googletest
 perl-TAP-Harness-Archive


### PR DESCRIPTION
In order to build and run CMocka test suites we need the libraries included in the -dev package.