### PR TITLE
Move to manual maintenance for `devpkg-gnu-efi`

### DIFF
--- a/auto.devpkgs
+++ b/auto.devpkgs
@@ -96,7 +96,6 @@ gnome-desktop-3.0
 gnome-settings-daemon
 gnome-software
 gnome-video-effects
-gnu-efi
 gnutls
 goa-1.0
 goa-backend-1.0

--- a/bundles/devpkg-gnu-efi
+++ b/bundles/devpkg-gnu-efi
@@ -8,3 +8,4 @@
 include(devpkg-base)
 
 gnu-efi-dev
+gnu-efi-staticdev


### PR DESCRIPTION
The `devpkg-gnu-efi` bundle is created automatically via the `auto.devpkgs`
mechanism. However, that mechanism does not add the `-staticdev` subpackage to
the bundle. This is problematic as it contains the required (static) libraries.
`gnu-efi` does not provide shared objects.

Because `gnu-efi` is rather unique in this, we drop the auto.devpkgs mechanism,
maintain the devpkg-gnu-efi bundle definition manually and add the
`gnu-efi-staticdev` subpackage to it.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>