### PR TITLE
Added decorator into machine-learning-tensorflow bundle.

### DIFF
--- a/bundles/machine-learning-tensorflow
+++ b/bundles/machine-learning-tensorflow
@@ -33,6 +33,7 @@ Werkzeug
 wheel
 wrapt
 include(openblas)
+decorator
 # end of custom additions
 
 # main package


### PR DESCRIPTION
BBT fail because of missing decorator dependency

Signed-off-by: Choong Yin Thong <yin.thong.choong@intel.com>