### PR TITLE
mixer: Remove container-basic

### DIFF
--- a/bundles/mixer
+++ b/bundles/mixer
@@ -27,9 +27,6 @@ rpm
 rpm-common
 bsdiff
 
-#TODO: Remove when built in Docker support is dropped
-include(containers-basic)
-
 #TODO: Update when ister is replaced by clr-installer
 include(os-installer)
 


### PR DESCRIPTION
Build in docker support has been removed in mixer 6.0.0, so
containers-basic is no longer needed.

Note: Mixer 6.0.0 has just been released. It will be included in the release following 31530 (currently, the latest).