### PR TITLE
gnupg: correct bundle description

### DIFF
--- a/bundles/gnupg
+++ b/bundles/gnupg
@@ -1,5 +1,5 @@
 # [TITLE]: gnupg
-# [DESCRIPTION]: zlib compression library
+# [DESCRIPTION]: The GNU Privacy Guard suite of programs
 # [STATUS]: Active
 # [CAPABILITIES]:
 # [TAGS]:


### PR DESCRIPTION
The "bungle" ;) was added with the incorrect description