### PR TITLE
Firefox: Fixed starting on kde only install

### DIFF
--- a/bundles/firefox
+++ b/bundles/firefox
@@ -7,6 +7,7 @@
 include(libX11client)
 include(desktop-gnomelibs)
 include(python3-basic)
+include(devpkg-dbus-glib)
 
 # dependencies
 gdk-pixbuf


### PR DESCRIPTION
Missing libdbus-glib-1.so.x on server install with desktop-kde bundle added.