### PR TITLE
Add dracut bundle

### DIFF
--- a/bundles/dracut
+++ b/bundles/dracut
@@ -1,0 +1,14 @@
+# [TITLE]: dracut
+# [DESCRIPTION]: dracut is an event driven initramfs infrastructure.
+# [STATUS]: Active
+# [CAPABILITIES]:
+# [TAGS]: Developer Tools
+# [MAINTAINER]: Daan De Meyer <daan.j.demeyer@gmail.com>
+
+
+# start of custom additions (edits outside this area will be removed automatically)
+include(binutils)
+# end of custom additions
+
+# main package
+dracut

--- a/bundles/sysadmin-basic
+++ b/bundles/sysadmin-basic
@@ -31,7 +31,7 @@ dfc
 include(diffutils)
 dmidecode
 dos2unix
-dracut
+include(dracut)
 e2fsprogs
 efibootmgr
 include(file)


### PR DESCRIPTION
Dracut is used for generating unified kernel images which can be signed
for use by Secure Boot. dracut itself requires binutils (objcopy) for
generating unified kernel images.

See https://systemd.io/BOOT_LOADER_SPECIFICATION/#type-2-efi-unified-kernel-images