### PR TITLE
simplify desktop-apps bundle

### DIFF
--- a/bundles/desktop-apps
+++ b/bundles/desktop-apps
@@ -15,11 +15,9 @@ also-add(cheese)
 also-add(connections)
 also-add(eog)
 also-add(evince)
-also-add(evolution)
 include(file-roller)
 also-add(flatpak)
 also-add(geary)
-also-add(gedit)
 also-add(gnome-calculator)
 also-add(gnome-characters)
 also-add(gnome-color-manager)
@@ -40,10 +38,8 @@ include(seahorse)
 also-add(totem)
 # apps
 dconf-editor
-graphviz-extras
 libyami-utils
 pavucontrol
-simple-scan
 
 # apps low level deps
 glib-bin


### PR DESCRIPTION
https://github.com/clearlinux/distribution/issues/2522

- remove evolution in favor of geary (never & faster UI)
- remove deprecated gedit in favor of gnome-text-editor (Wayland-native)
- move simple-scan to hardware-printing bundle
- remove graphviz-extras - no sense to provide graph viewer here