### PR TITLE
Fix type: smarctl -> smartctl.

### DIFF
--- a/bundles/smartmontools
+++ b/bundles/smartmontools
@@ -1,5 +1,5 @@
 # [TITLE]: smartmontools
-# [DESCRIPTION]: Hard disk diagnostic utilities, containing smarctl and smartd, for monitoring storage.
+# [DESCRIPTION]: Hard disk diagnostic utilities, containing smartctl and smartd, for monitoring storage.
 # [STATUS]: Active
 # [CAPABILITIES]:
 # [TAGS]: Tools and Utilities


### PR DESCRIPTION
Fix a typo in smartmontools bundle description. That shows up on https://clearlinux.org/software/bundle/smartmontools.